### PR TITLE
Fix ReadInt64 issue

### DIFF
--- a/src/Be.IO/Helpers/BigEndian.cs
+++ b/src/Be.IO/Helpers/BigEndian.cs
@@ -21,8 +21,8 @@ namespace Be.IO.Helpers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long ReadInt64(byte* p)
         {
-            int lo = ReadInt32(p);
-            int hi = ReadInt32(p + 4);
+            int hi = ReadInt32(p);
+            int lo = ReadInt32(p + 4);
             return (long)hi << 32 | (uint)lo;
         }
 


### PR DESCRIPTION
There was a mistake when reading a 8 bytes value.
Can be tested with following code:

        [TestMethod]
        public void TestUInt64()
        {
            using (MemoryStream ms = new MemoryStream())
            {
                ulong src = 1;
                var bw = new BeBinaryWriter(ms);
                bw.Write(src);
                bw.Flush();
                ms.Seek(0, SeekOrigin.Begin);
                var br = new BeBinaryReader(ms);
                var dst = br.ReadUInt64();
                Assert.AreEqual(src, dst); //Expect 1, Actual 4294967296
            }
        }

By the way, I haven't figure out how to create a UnitTest project for this lib --- VS refused to add this lib as a reference when creating a VSUnitTest project. (Maybe DNX project is not supported?)