### PR TITLE
Fix ReadBoolean and ReadSByte reading wrong buffer

### DIFF
--- a/src/Be.IO/BeBinaryReader.cs
+++ b/src/Be.IO/BeBinaryReader.cs
@@ -30,6 +30,18 @@ namespace Be.IO
             this.buffer = new byte[bufferSize];
         }
 
+        public override bool ReadBoolean()
+        {
+            FillBuffer(1);
+            return (buffer[0] != 0);
+        }
+
+        public override sbyte ReadSByte()
+        {
+            FillBuffer(1);
+            return (sbyte)(buffer[0]);
+        }
+
         public override decimal ReadDecimal()
         {
             FillBuffer(16);


### PR DESCRIPTION
Fixes #3.
## Explanation
From the [reference source implementation](https://referencesource.microsoft.com/#mscorlib/system/io/binaryreader.cs,441453fdc4e511bf) of `BinaryReader`:
```c#
public virtual bool ReadBoolean(){
    FillBuffer(1);
    return (m_buffer[0]!=0);
}
```
```c#
public virtual sbyte ReadSByte() {
    FillBuffer(1);
    return (sbyte)(m_buffer[0]);
}
```
These two functions first call the `FillBuffer(int numBytes)` method, which is overloaded by `BeBinaryReader` and therefore reads the specified amount of bytes into it's **own protected field** aka. `buffer` instead of the private field `m_buffer` that `BinaryReader` uses and which is also read by the afore mentioned read methods, causing them to fail silently (reading a zero-byte from the empty but still allocated `m_buffer`).

I've re-implemented these methods in `BeBinaryReader`, so that they the `buffer` field instead. The `BeBinaryWriter` implementation doesn't seem to be affected by this problem.

Hope this helps!